### PR TITLE
fix a bug on customPermissions

### DIFF
--- a/ern-container-gen-android/src/AndroidGenerator.ts
+++ b/ern-container-gen-android/src/AndroidGenerator.ts
@@ -92,6 +92,7 @@ export default class AndroidGenerator implements ContainerGenerator {
     let mustacheView: any = {
       customRepos: [],
       permissions: [],
+      customPermissions: []
     }
     injectReactNativeVersionKeysInObject(
       mustacheView,


### PR DESCRIPTION
encountered "Cannot read property 'push' of undefined" when generate a android container